### PR TITLE
Cria opção de usar dados já descarregados na máquina local.

### DIFF
--- a/R/candidate_fed.R
+++ b/R/candidate_fed.R
@@ -121,12 +121,7 @@ candidate_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, e
   uf <- test_uf(uf)
   test_br(br_archive)
 
-  # Download the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_cand/consulta_cand_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+  download_and_unzip_datafile(sprintf('odsele/consulta_cand/consulta_cand_%s.zip', year), year)
 
   message("Processing the data...")
 

--- a/R/candidate_fed.R
+++ b/R/candidate_fed.R
@@ -114,26 +114,15 @@
 
 candidate_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
 
-
   # Input tests
   test_encoding(encoding)
   test_fed_year(year)
   uf <- test_uf(uf)
   test_br(br_archive)
 
-  download_and_unzip_datafile(sprintf('odsele/consulta_cand/consulta_cand_%s.zip', year), year)
-
-  message("Processing the data...")
-
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, br_archive)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-
-  # Change variable names
+  # Variable names
   if(year < 2014){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "DESCRICAO_UE", "CODIGO_CARGO", "DESCRICAO_CARGO",
                       "NOME_CANDIDATO", "SEQUENCIAL_CANDIDATO", "NUMERO_CANDIDATO", "CPF_CANDIDATO",
                       "NOME_URNA_CANDIDATO", "COD_SITUACAO_CANDIDATURA", "DES_SITUACAO_CANDIDATURA",
@@ -147,7 +136,7 @@ candidate_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, e
                       "DESC_SIT_TOT_TURNO")
 
   }else{
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",
                       "NUM_TURNO", "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "ABRANGENCIA", 
                       "SIGLA_UF", "SIGLA_UE", "DESCRICAO_UE", "CODIGO_CARGO", "DESCRICAO_CARGO", 
                       "SEQUENCIAL_CANDIDATO", "NUMERO_CANDIDATO", "NOME_CANDIDATO", "NOME_URNA_CANDIDATO", 
@@ -163,13 +152,7 @@ candidate_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, e
                       "SITUACAO_REELEICAO", "SITUACAO_DECLARAR_BENS", "NUMERO_PROTOCOLO_CANDIDATURA", 
                       "NUMERO_PROCESSO")
   }
-  
-  # Change to ascii
-  if(ascii) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
-  
-  message("Done.\n")
-  return(banco)
+
+  get_data('consulta_cand', year, uf, br_archive, ascii, encoding, export, data_names)
 }
+

--- a/R/candidate_local.R
+++ b/R/candidate_local.R
@@ -92,13 +92,8 @@ candidate_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1"
   test_encoding(encoding)
   test_local_year(year)
   uf <- test_uf(uf)
-  
-  # Downloads the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_cand/consulta_cand_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+
+  download_and_unzip_datafile(sprintf("odsele/consulta_cand/consulta_cand_%s.zip", year), year)
 
   message("Processing the data...")
 

--- a/R/candidate_local.R
+++ b/R/candidate_local.R
@@ -93,19 +93,9 @@ candidate_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1"
   test_local_year(year)
   uf <- test_uf(uf)
 
-  download_and_unzip_datafile(sprintf("odsele/consulta_cand/consulta_cand_%s.zip", year), year)
-
-  message("Processing the data...")
-
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, FALSE)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-
   # Changes variables names
   if(year < 2012){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "DESCRICAO_UE", "CODIGO_CARGO", "DESCRICAO_CARGO",
                       "NOME_CANDIDATO", "SEQUENCIAL_CANDIDATO", "NUMERO_CANDIDATO", "CPF_CANDIDATO",
                       "NOME_URNA_CANDIDATO", "COD_SITUACAO_CANDIDATURA", "DES_SITUACAO_CANDIDATURA",
@@ -117,9 +107,8 @@ candidate_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1"
                       "DESCRICAO_NACIONALIDADE", "SIGLA_UF_NASCIMENTO", "CODIGO_MUNICIPIO_NASCIMENTO",
                       "NOME_MUNICIPIO_NASCIMENTO", "DESPESA_MAX_CAMPANHA", "COD_SIT_TOT_TURNO",
                       "DESC_SIT_TOT_TURNO")
-
   } else if(year == 2012) {
-    names(banco) <-c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <-c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                      "SIGLA_UF", "SIGLA_UE", "DESCRICAO_UE", "CODIGO_CARGO", "DESCRICAO_CARGO",
                      "NOME_CANDIDATO", "SEQUENCIAL_CANDIDATO", "NUMERO_CANDIDATO", "CPF_CANDIDATO",
                      "NOME_URNA_CANDIDATO", "COD_SITUACAO_CANDIDATURA", "DES_SITUACAO_CANDIDATURA",
@@ -131,10 +120,8 @@ candidate_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1"
                      "DESCRICAO_NACIONALIDADE", "SIGLA_UF_NASCIMENTO", "CODIGO_MUNICIPIO_NASCIMENTO",
                      "NOME_MUNICIPIO_NASCIMENTO", "DESPESA_MAX_CAMPANHA", "COD_SIT_TOT_TURNO",
                      "DESC_SIT_TOT_TURNO", "EMAIL_CANDIDATO")
-    
   } else {
-    
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",
                       "NUM_TURNO", "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "ABRANGENCIA", 
                       "SIGLA_UF", "SIGLA_UE", "DESCRICAO_UE", "CODIGO_CARGO", "DESCRICAO_CARGO", 
                       "SEQUENCIAL_CANDIDATO", "NUMERO_CANDIDATO", "NOME_CANDIDATO", "NOME_URNA_CANDIDATO", 
@@ -149,15 +136,7 @@ candidate_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1"
                       "DESCRICAO_OCUPACAO", "DESPESA_MAX_CAMPANHA", "COD_SIT_TOT_TURNO", "DESC_SIT_TOT_TURNO",
                       "SITUACAO_REELEICAO", "SITUACAO_DECLARAR_BENS", "NUMERO_PROTOCOLO_CANDIDATURA", 
                       "NUMERO_PROCESSO")
-    
   }
-  
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
-  
-  message("Done.\n")
-  return(banco)
+
+  get_data('consulta_cand', year, uf, FALSE, ascii, encoding, export, data_names)
 }

--- a/R/details_mun_zone_fed.R
+++ b/R/details_mun_zone_fed.R
@@ -91,12 +91,7 @@ details_mun_zone_fed <- function(year, uf = "all", br_archive = FALSE, ascii = F
   uf <- test_uf(uf)
   test_br(br_archive)
 
-  # Downloads the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/detalhe_votacao_munzona/detalhe_votacao_munzona_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+  download_and_unzip_datafile(sprintf("odsele/detalhe_votacao_munzona/detalhe_votacao_munzona_%s.zip", year), year)
 
   message("Processing the data...")
 

--- a/R/details_mun_zone_fed.R
+++ b/R/details_mun_zone_fed.R
@@ -84,26 +84,15 @@
 
 details_mun_zone_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
 
-
   # Input tests
   test_encoding(encoding)
   test_fed_year(year)
   uf <- test_uf(uf)
   test_br(br_archive)
 
-  download_and_unzip_datafile(sprintf("odsele/detalhe_votacao_munzona/detalhe_votacao_munzona_%s.zip", year), year)
-
-  message("Processing the data...")
-
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, br_archive)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-
-  # Changes variables names
+  # Variables names
   if(year < 2014){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                       "CODIGO_CARGO", "DESCRICAO_CARGO", "QTD_APTOS", "QTD_SECOES", "QTD_SECOES_AGREGADAS",
                       "QTD_APTOS_TOT", "QTD_SECOES_TOT", "QTD_COMPARECIMENTO", "QTD_ABSTENCOES",
@@ -111,7 +100,7 @@ details_mun_zone_fed <- function(year, uf = "all", br_archive = FALSE, ascii = F
                       "QTD_VOTOS_ANULADOS_APU_SEP", "DATA_ULT_TOTALIZACAO", "HORA_ULT_TOTALIZACAO")
 
   } else if( year == 2014 ) {
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                       "CODIGO_CARGO", "DESCRICAO_CARGO", "QTD_APTOS", "QTD_SECOES", "QTD_SECOES_AGREGADAS",
                       "QTD_APTOS_TOT", "QTD_SECOES_TOT", "QTD_COMPARECIMENTO", "QTD_ABSTENCOES",
@@ -120,7 +109,7 @@ details_mun_zone_fed <- function(year, uf = "all", br_archive = FALSE, ascii = F
                       "VAR_NAO_DECLARADA_DOC_TSE")
     
   } else{
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",     
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",     
                       "NUM_TURNO", "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "ABRANGENCIA", "SIGLA_UF",
                       "SIGLA_UE", "NOME_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA", "CODIGO_CARGO",
                       "DESCRICAO_CARGO", "QTD_APTOS", "QTD_SECOES", "QTD_SECOES_AGREGADAS", "QTD_APTOS_TOT",
@@ -128,13 +117,6 @@ details_mun_zone_fed <- function(year, uf = "all", br_archive = FALSE, ascii = F
                       "QTD_VOTOS_BRANCOS", "QTD_VOTOS_NULOS", "QTD_VOTOS_LEGENDA", "QTD_VOTOS_PENDENTES",
                       "QTD_VOTOS_ANULADOS", "HORA_ULT_TOTALIZACAO", "DATA_ULT_TOTALIZACAO")
   }
-  
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
 
-  message("Done.\n")
-  return(banco)
+  get_data('detalhe_votacao_munzona', year, uf, br_archive, ascii, encoding, export, data_names)
 }

--- a/R/details_mun_zone_local.R
+++ b/R/details_mun_zone_local.R
@@ -73,19 +73,9 @@ details_mun_zone_local <- function(year, uf = "all", ascii = FALSE, encoding = "
   test_local_year(year)
   uf <- test_uf(uf)
 
-  download_and_unzip_datafile(sprintf("odsele/detalhe_votacao_munzona/detalhe_votacao_munzona_%s.zip", year), year)
-
-  message("Processing the data...")
-
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, FALSE)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-
-  # Changes variables names
+  # Variables names
   if(year <= 2012){
-     names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                        "SIGLA_UF", "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                        "CODIGO_CARGO", "DESCRICAO_CARGO", "QTD_APTOS", "QTD_SECOES", "QTD_SECOES_AGREGADAS",
                        "QTD_APTOS_TOT", "QTD_SECOES_TOT", "QTD_COMPARECIMENTO", "QTD_ABSTENCOES",
@@ -93,8 +83,7 @@ details_mun_zone_local <- function(year, uf = "all", ascii = FALSE, encoding = "
                        "QTD_VOTOS_ANULADOS_APU_SEP", "DATA_ULT_TOTALIZACAO", "HORA_ULT_TOTALIZACAO")
 
   } else {
-    
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",     
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",     
                       "NUM_TURNO", "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "ABRANGENCIA", "SIGLA_UF",
                       "SIGLA_UE", "NOME_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA", "CODIGO_CARGO",
                       "DESCRICAO_CARGO", "QTD_APTOS", "QTD_SECOES", "QTD_SECOES_AGREGADAS", "QTD_APTOS_TOT",
@@ -102,13 +91,6 @@ details_mun_zone_local <- function(year, uf = "all", ascii = FALSE, encoding = "
                       "QTD_VOTOS_BRANCOS", "QTD_VOTOS_NULOS", "QTD_VOTOS_LEGENDA", "QTD_VOTOS_PENDENTES",
                       "QTD_VOTOS_ANULADOS", "HORA_ULT_TOTALIZACAO", "DATA_ULT_TOTALIZACAO")
   }
-  
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
 
-  message("Done.\n")
-  return(banco)
+  get_data("detalhe_votacao_munzona", year, uf, FALSE, ascii, encoding, export, data_names)
 }

--- a/R/details_mun_zone_local.R
+++ b/R/details_mun_zone_local.R
@@ -68,18 +68,12 @@
 
 details_mun_zone_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1", export = FALSE){
 
-
   # Input tests
   test_encoding(encoding)
   test_local_year(year)
   uf <- test_uf(uf)
 
-  # Downloads the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/detalhe_votacao_munzona/detalhe_votacao_munzona_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+  download_and_unzip_datafile(sprintf("odsele/detalhe_votacao_munzona/detalhe_votacao_munzona_%s.zip", year), year)
 
   message("Processing the data...")
 

--- a/R/legend_fed.R
+++ b/R/legend_fed.R
@@ -64,7 +64,6 @@
 
 legend_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
 
-
   # Test the input
   test_encoding(encoding)
   test_fed_year(year)
@@ -72,41 +71,24 @@ legend_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, enco
   test_br(br_archive)
 
   if(year < 2018) {
-    endereco <- "odsele/consulta_legendas/consulta_legendas_%s.zip"
+    data_name <- "consulta_legendas"
   } else{
-    endereco <- "odsele/consulta_coligacao/consulta_coligacao_%s.zip"
+    data_name <- "consulta_coligacao"
   }
 
-  download_and_unzip_datafile(sprintf(endereco, year), year)
-
-  message("Processing the data...")
-
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, br_archive)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-
-  # Change variable names
+  # Variable names
   if(year < 2018) {
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "NOME_MUNICIPIO", "CODIGO_CARGO", "DESCRICAO_CARGO",
                       "TIPO_LEGENDA", "NUMERO_PARTIDO", "SIGLA_PARTIDO", "NOME_PARTIDO", "SIGLA_COLIGACAO",
                       "NOME_COLIGACAO", "COMPOSICAO_COLIGACAO", "SEQUENCIAL_COLIGACAO")
   } else{
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NM_TIPO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NM_TIPO_ELEICAO",
                       "NUM_TURNO", "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "SIGLA_UF",
                       "SIGLA_UE", "NOME_MUNICIPIO", "CODIGO_CARGO", "DESCRICAO_CARGO", "TIPO_LEGENDA",
                       "NUMERO_PARTIDO", "SIGLA_PARTIDO", "NOME_PARTIDO", "SEQUENCIAL_COLIGACAO",
                       "NOME_COLIGACAO", "COMPOSICAO_COLIGACAO")
   }
 
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-    
-  # Export
-  if(export) export_data(banco)
-
-  message("Done.\n")
-  return(banco)
+  get_data(data_name, year, uf, br_archive, ascii, encoding, export, data_names)
 }

--- a/R/legend_fed.R
+++ b/R/legend_fed.R
@@ -70,20 +70,14 @@ legend_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, enco
   test_fed_year(year)
   uf <- test_uf(uf)
   test_br(br_archive)
-  
-  
+
   if(year < 2018) {
-    endereco <- "http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_legendas/consulta_legendas_%s.zip"
+    endereco <- "odsele/consulta_legendas/consulta_legendas_%s.zip"
   } else{
-    endereco <- "http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_coligacao/consulta_coligacao_%s.zip"
+    endereco <- "odsele/consulta_coligacao/consulta_coligacao_%s.zip"
   }
 
-  # Download the data
-  dados <- tempfile()
-  sprintf(endereco, year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+  download_and_unzip_datafile(sprintf(endereco, year), year)
 
   message("Processing the data...")
 
@@ -106,8 +100,7 @@ legend_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, enco
                       "NUMERO_PARTIDO", "SIGLA_PARTIDO", "NOME_PARTIDO", "SEQUENCIAL_COLIGACAO",
                       "NOME_COLIGACAO", "COMPOSICAO_COLIGACAO")
   }
-  
-  
+
   # Change to ascii
   if(ascii == T) banco <- to_ascii(banco, encoding)
     

--- a/R/legend_local.R
+++ b/R/legend_local.R
@@ -58,40 +58,20 @@
 
 legend_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1", export = FALSE){
 
+  if(year <= 2004){
+    stop("Not disponible. Please, check the documentation and try again.\n")
+  }
 
   # Test the input
   test_encoding(encoding)
   test_local_year(year)
   uf <- test_uf(uf)
   
-  if(year > 2004){
-    download_and_unzip_datafile(sprintf("odsele/consulta_legendas/consulta_legendas_%s.zip", year), year)
+  # Variable names
+  data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+                    "SIGLA_UF", "SIGLA_UE", "NOME_MUNICIPIO", "CODIGO_CARGO", "DESCRICAO_CARGO",
+                    "TIPO_LEGENDA", "NUMERO_PARTIDO", "SIGLA_PARTIDO", "NOME_PARTIDO", "SIGLA_COLIGACAO",
+                    "NOME_COLIGACAO", "COMPOSICAO_COLIGACAO", "SEQUENCIAL_COLIGACAO")
 
-    message("Processing the data...")
-    
-    # Cleans the data
-    setwd(as.character(year))
-    banco <- juntaDados(uf, encoding, FALSE)
-    setwd("..")
-    unlink(as.character(year), recursive = T)
-    
-    # Change variable names
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
-                      "SIGLA_UF", "SIGLA_UE", "NOME_MUNICIPIO", "CODIGO_CARGO", "DESCRICAO_CARGO",
-                      "TIPO_LEGENDA", "NUMERO_PARTIDO", "SIGLA_PARTIDO", "NOME_PARTIDO", "SIGLA_COLIGACAO",
-                      "NOME_COLIGACAO", "COMPOSICAO_COLIGACAO", "SEQUENCIAL_COLIGACAO")
-    
-    # Change to ascii
-    if(ascii == T) banco <- to_ascii(banco, encoding)
-    
-    # Export
-    if(export) export_data(banco)
-    
-    message("Done.\n")
-    return(banco)
-  }else{
-    message("Not disponible. Please, check the documentation and try again.\n")
-  }
-
- 
+  get_data('consulta_legendas', year, uf, FALSE, ascii, encoding, export, data_names)
 }

--- a/R/legend_local.R
+++ b/R/legend_local.R
@@ -65,13 +65,8 @@ legend_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1", e
   uf <- test_uf(uf)
   
   if(year > 2004){
-    # Download the data
-    dados <- tempfile()
-    sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_legendas/consulta_legendas_%s.zip", year) %>%
-      download.file(dados)
-    unzip(dados, exdir = paste0("./", year))
-    unlink(dados)
-    
+    download_and_unzip_datafile(sprintf("odsele/consulta_legendas/consulta_legendas_%s.zip", year), year)
+
     message("Processing the data...")
     
     # Cleans the data

--- a/R/party_mun_zone_fed.R
+++ b/R/party_mun_zone_fed.R
@@ -75,8 +75,7 @@
 #' df <- party_mun_zone_fed(2002)
 #' }
 
-party_mun_zone_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
-
+party_mun_zone_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
 
   # Test the input
   test_encoding(encoding)
@@ -84,45 +83,28 @@ party_mun_zone_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FA
   uf <- test_uf(uf)
   test_br(br_archive)
 
-  download_and_unzip_datafile(sprintf("odsele/votacao_partido_munzona/votacao_partido_munzona_%s.zip", year), year)
-
-  message("Processing the data...")
-
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, br_archive)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-
-  # Change variable names
+  # Variable names
   if(year < 2014){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                       "CODIGO_CARGO", "DESCRICAO_CARGO", "TIPO_LEGENDA", "NOME_COLIGACAO", "COMPOSICAO_LEGENDA",
                       "SIGLA_PARTIDO", "NUMERO_PARTIDO", "NOME_PARTIDO", "QTDE_VOTOS_NOMINAIS",
                       "QTDE_VOTOS_LEGENDA", "SEQUENCIAL_LEGENDA")
 
   } else if(year == 2014){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                       "CODIGO_CARGO", "DESCRICAO_CARGO", "TIPO_LEGENDA", "NOME_COLIGACAO", "COMPOSICAO_LEGENDA",
                       "SIGLA_PARTIDO", "NUMERO_PARTIDO", "NOME_PARTIDO", "QTDE_VOTOS_NOMINAIS",
                       "QTDE_VOTOS_LEGENDA", "TRANSITO", "SEQUENCIAL_LEGENDA")
   } else{
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",
                       "NUM_TURNO", "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "ABRANGENCIA",
                       "SIGLA_UF", "SIGLA_UE", "NOME_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                       "CODIGO_CARGO", "DESCRICAO_CARGO", "TIPO_LEGENDA", "NUMERO_PARTIDO", "SIGLA_PARTIDO",
                       "NOME_PARTIDO", "SEQUENCIAL_LEGENDA", "NOME_COLIGACAO", "COMPOSICAO_LEGENDA", 
                       "TRANSITO", "QTDE_VOTOS_NOMINAIS", "QTDE_VOTOS_LEGENDA")
   }
-  
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
-
-  message("Done.\n")
-  return(banco)
+    
+  get_data('votacao_partido_munzona', year, uf, br_archive, ascii, encoding, export, data_names)
 }

--- a/R/party_mun_zone_fed.R
+++ b/R/party_mun_zone_fed.R
@@ -84,15 +84,10 @@ party_mun_zone_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FA
   uf <- test_uf(uf)
   test_br(br_archive)
 
-  # Download the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/votacao_partido_munzona/votacao_partido_munzona_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+  download_and_unzip_datafile(sprintf("odsele/votacao_partido_munzona/votacao_partido_munzona_%s.zip", year), year)
 
   message("Processing the data...")
-  
+
   # Cleans the data
   setwd(as.character(year))
   banco <- juntaDados(uf, encoding, br_archive)

--- a/R/party_mun_zone_local.R
+++ b/R/party_mun_zone_local.R
@@ -70,15 +70,9 @@ party_mun_zone_local <- function(year, uf = "all", ascii = FALSE, encoding = "la
   test_local_year(year)
   uf <- test_uf(uf)
 
-  # Download the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/votacao_partido_munzona/votacao_partido_munzona_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+  download_and_unzip_datafile(sprintf("odsele/votacao_partido_munzona/votacao_partido_munzona_%s.zip", year), year)
 
   message("Processing the data...")
-
 
   # Cleans the data
   setwd(as.character(year))

--- a/R/party_mun_zone_local.R
+++ b/R/party_mun_zone_local.R
@@ -64,45 +64,26 @@
 
 party_mun_zone_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1", export = FALSE){
 
-
   # Test the input
   test_encoding(encoding)
   test_local_year(year)
   uf <- test_uf(uf)
 
-  download_and_unzip_datafile(sprintf("odsele/votacao_partido_munzona/votacao_partido_munzona_%s.zip", year), year)
-
-  message("Processing the data...")
-
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, FALSE)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-
-  # Change variable names
+  # Variable names
   if(year <= 2012){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                       "CODIGO_CARGO", "DESCRICAO_CARGO", "TIPO_LEGENDA", "NOME_COLIGACAO", "COMPOSICAO_LEGENDA",
                       "SIGLA_PARTIDO", "NUMERO_PARTIDO", "NOME_PARTIDO", "QTDE_VOTOS_NOMINAIS",
                       "QTDE_VOTOS_LEGENDA", "SEQUENCIAL_LEGENDA")
   } else {
-    
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",
                       "NUM_TURNO", "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "ABRANGENCIA", "SIGLA_UF",
                       "SIGLA_UE", "NOME_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA", "CODIGO_CARGO",
                       "DESCRICAO_CARGO", "TIPO_LEGENDA", "NUMERO_PARTIDO", "SIGLA_PARTIDO", "NOME_PARTIDO",     
                       "SEQUENCIAL_LEGENDA", "NOME_COLIGACAO", "COMPOSICAO_LEGENDA", "TRANSITO", "QTDE_VOTOS_NOMINAIS",
                       "QTDE_VOTOS_LEGENDA")
  }
-    
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
 
-  # Export
-  if(export) export_data(banco)
-  
-  message("Done.\n")
-  return(banco)
+  get_data('votacao_partido_munzona', year, uf, FALSE, ascii, encoding, export, data_names)
 }

--- a/R/personal_finances_fed.R
+++ b/R/personal_finances_fed.R
@@ -72,13 +72,8 @@ personal_finances_fed <- function(year, uf = "all",  br_archive = FALSE, ascii =
   
   if(year < 2006) stop("Not disponible. Please, check the documentation and try again.\n")
     
-    # Downloads the data
-    dados <- tempfile()
-    sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/bem_candidato/bem_candidato_%s.zip", year) %>%
-      download.file(dados)
-    unzip(dados, exdir = paste0("./", year))
-    unlink(dados)
-    
+    download_and_unzip_datafile(sprintf("odsele/bem_candidato/bem_candidato_%s.zip", year), year)
+  
     message("Processing the data...")
     
     # Cleans the data
@@ -109,6 +104,4 @@ personal_finances_fed <- function(year, uf = "all",  br_archive = FALSE, ascii =
     
     message("Done.\n")
     return(banco)
-} 
-
-  
+}

--- a/R/personal_finances_fed.R
+++ b/R/personal_finances_fed.R
@@ -62,46 +62,30 @@
 #' df <- personal_finances_fed(2006)
 #' }
 
-personal_finances_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
+personal_finances_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE) {
   
+  if(year < 2006){
+    stop("Not disponible. Please, check the documentation and try again.\n") 
+  }
+
   # Input tests
   test_encoding(encoding)
   test_fed_year(year)
   uf <- test_uf(uf)
   test_br(br_archive)
   
-  if(year < 2006) stop("Not disponible. Please, check the documentation and try again.\n")
-    
-    download_and_unzip_datafile(sprintf("odsele/bem_candidato/bem_candidato_%s.zip", year), year)
+  # Variables names
+  if(year < 2014){
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "DESCRICAO_ELEICAO",
+                      "SIGLA_UF", "SQ_CANDIDATO", "CD_TIPO_BEM_CANDIDATO", "DS_TIPO_BEM_CANDIDATO",
+                      "DETALHE_BEM", "VALOR_BEM", "DATA_ULT_TOTALIZACAO", "HORA_ULT_TOTALIZACAO")
+  } else{
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",      
+                       "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "SIGLA_UF", "SIGLA_UE",               
+                       "NOME_UE", "SQ_CANDIDATO", "NUMERO_ORDEM_CANDIDATO", "CD_TIPO_BEM_CANDIDATO",
+                       "DS_TIPO_BEM_CANDIDATO", "DETALHE_BEM", "VALOR_BEM", "DT_ULTIMA_ATUALIZACAO",
+                       "HH_ULTIMA_ATUALIZACAO")
+  }
   
-    message("Processing the data...")
-    
-    # Cleans the data
-    setwd(as.character(year))
-    banco <- juntaDados(uf, encoding, br_archive)
-    setwd("..")
-    unlink(as.character(year), recursive = T)
-    
-    # Changes variables names
-    if(year < 2014){
-      names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "DESCRICAO_ELEICAO",
-                        "SIGLA_UF", "SQ_CANDIDATO", "CD_TIPO_BEM_CANDIDATO", "DS_TIPO_BEM_CANDIDATO",
-                        "DETALHE_BEM", "VALOR_BEM", "DATA_ULT_TOTALIZACAO", "HORA_ULT_TOTALIZACAO")
-    } else{
-      names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",      
-                         "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "SIGLA_UF", "SIGLA_UE",               
-                         "NOME_UE", "SQ_CANDIDATO", "NUMERO_ORDEM_CANDIDATO", "CD_TIPO_BEM_CANDIDATO",
-                         "DS_TIPO_BEM_CANDIDATO", "DETALHE_BEM", "VALOR_BEM", "DT_ULTIMA_ATUALIZACAO",
-                         "HH_ULTIMA_ATUALIZACAO")
-    }
-    
-    
-    # Change to ascii
-    if(ascii == T) banco <- to_ascii(banco, encoding)
-    
-    # Export
-    if(export) export_data(banco)
-    
-    message("Done.\n")
-    return(banco)
+  get_data('bem_candidato', year, uf, br_archive, ascii, encoding, export, data_names)
 }

--- a/R/personal_finances_local.R
+++ b/R/personal_finances_local.R
@@ -46,45 +46,25 @@
 #' df <- personal_finances_local(2000)
 #' }
 
-personal_finances_local <- function(year, uf = "all",  ascii = FALSE, encoding = "latin1", export = FALSE){
-  
+personal_finances_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1", export = FALSE){
   
   # Input tests
   test_encoding(encoding)
   test_local_year(year)
   uf <- test_uf(uf)
-  
-  download_and_unzip_datafile(sprintf("odsele/bem_candidato/bem_candidato_%s.zip", year), year)
 
-  message("Processing the data...")
-  
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, FALSE)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-  
-  # Changes variables names
+  # Variables names
   if(year < 2012){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SQ_CANDIDATO", "CD_TIPO_BEM_CANDIDATO", "DS_TIPO_BEM_CANDIDATO",
                       "DETALHE_BEM", "VALOR_BEM", "DATA_ULT_TOTALIZACAO", "HORA_ULT_TOTALIZACAO")
   } else{
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",      
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO",      
                       "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "SIGLA_UF", "SIGLA_UE",                
                       "NOME_UE", "SQ_CANDIDATO", "NUMERO_ORDEM_CANDIDATO", "CD_TIPO_BEM_CANDIDATO",
                       "DS_TIPO_BEM_CANDIDATO", "DETALHE_BEM", "VALOR_BEM", "DT_ULTIMA_ATUALIZACAO",
                       "HH_ULTIMA_ATUALIZACAO")
   }
-  
- 
-  
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
-  
-  message("Done.\n")
-  return(banco)
+
+  get_data('bem_candidato', year, uf, FALSE, ascii, encoding, export, data_names)
 }

--- a/R/personal_finances_local.R
+++ b/R/personal_finances_local.R
@@ -54,13 +54,8 @@ personal_finances_local <- function(year, uf = "all",  ascii = FALSE, encoding =
   test_local_year(year)
   uf <- test_uf(uf)
   
-  # Downloads the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/bem_candidato/bem_candidato_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
-  
+  download_and_unzip_datafile(sprintf("odsele/bem_candidato/bem_candidato_%s.zip", year), year)
+
   message("Processing the data...")
   
   # Cleans the data

--- a/R/seats_fed.R
+++ b/R/seats_fed.R
@@ -53,8 +53,7 @@
 #' df <- seats_fed(2000)
 #' }
 
-seats_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
-  
+seats_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
   
   # Input tests
   test_encoding(encoding)
@@ -62,34 +61,17 @@ seats_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FALSE, enco
   uf <- test_uf(uf)
   test_br(br_archive)
 
-  download_and_unzip_datafile(sprintf("odsele/consulta_vagas/consulta_vagas_%s.zip", year), year)
-
-  message("Processing the data...")
-  
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, br_archive)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-  
-  # Change variable names
+  # Variable names
   if(year < 2014){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "NOME_UE", "CODIGO_CARGO", "DESCRICAO_CARGO",
                       "QTDE_VAGAS")
   }else{
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", 
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", 
                       "NOME_TIPO_ELEICAO", "COD_ELEICAO", "DESCRICAO_ELEICAO", 
                       "DATA_ELEICAO", "DATA_POSSE", "SIGLA_UF", "SIGLA_UE", "NOME_UE",        
                       "CODIGO_CARGO", "DESCRICAO_CARGO", "QTDE_VAGAS" )
   }
 
-  # Change to ascii
-  if(ascii) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
-  
-  message("Done.\n")
-  return(banco)
+  get_data('consulta_vagas', year, uf, br_archive, ascii, encoding, export, data_names)
 }

--- a/R/seats_fed.R
+++ b/R/seats_fed.R
@@ -61,14 +61,9 @@ seats_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FALSE, enco
   test_fed_year(year)
   uf <- test_uf(uf)
   test_br(br_archive)
-  
-  # Download the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_vagas/consulta_vagas_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
-  
+
+  download_and_unzip_datafile(sprintf("odsele/consulta_vagas/consulta_vagas_%s.zip", year), year)
+
   message("Processing the data...")
   
   # Cleans the data
@@ -89,7 +84,6 @@ seats_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FALSE, enco
                       "CODIGO_CARGO", "DESCRICAO_CARGO", "QTDE_VAGAS" )
   }
 
-  
   # Change to ascii
   if(ascii) banco <- to_ascii(banco, encoding)
   
@@ -99,4 +93,3 @@ seats_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FALSE, enco
   message("Done.\n")
   return(banco)
 }
-

--- a/R/seats_local.R
+++ b/R/seats_local.R
@@ -51,41 +51,22 @@
 
 seats_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1", export = FALSE){
   
-  
   # Input tests
   test_encoding(encoding)
   test_local_year(year)
   uf <- test_uf(uf)
-
-  download_and_unzip_datafile(sprintf("odsele/consulta_vagas/consulta_vagas_%s.zip", year), year)
-  
-  message("Processing the data...")
-  
-  # Cleans the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, FALSE)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
   
   # Change variable names
-if( year < 2016 ){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "DESCRICAO_ELEICAO",
+  if (year < 2016) {
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "DESCRICAO_ELEICAO",
                     "SIGLA_UF", "SIGLA_UE", "NOME_UE", "CODIGO_CARGO", "DESCRICAO_CARGO",
                     "QTDE_VAGAS")
- } else{
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", 
+  } else {
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", 
                       "NOME_TIPO_ELEICAO", "COD_ELEICAO", "DESCRICAO_ELEICAO", 
                       "DATA_ELEICAO", "DATA_POSSE", "SIGLA_UF", "SIGLA_UE", "NOME_UE",        
                       "CODIGO_CARGO", "DESCRICAO_CARGO", "QTDE_VAGAS" )
   }
-  
-  # Change to ascii
-  if(ascii) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
-  
-  message("Done.\n")
-  return(banco)
-}
 
+  get_data('consulta_vagas', year, uf, FALSE, ascii, encoding, export, data_names)
+}

--- a/R/seats_local.R
+++ b/R/seats_local.R
@@ -56,13 +56,8 @@ seats_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1", ex
   test_encoding(encoding)
   test_local_year(year)
   uf <- test_uf(uf)
-  
-  # Download the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_vagas/consulta_vagas_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+
+  download_and_unzip_datafile(sprintf("odsele/consulta_vagas/consulta_vagas_%s.zip", year), year)
   
   message("Processing the data...")
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -159,6 +159,14 @@ export_data <- function(df) {
   message(paste0("Electoral data files were saved on: ", getwd(), ".\n"))
 }
 
+download_and_unzip_datafile <- function(str_endpoint, year) {
+  str_base_url <- 'http://agencia.tse.jus.br/estatistica/sead/%s'
+
+  tmp_data_file <- tempfile()
+  download.file(sprintf(str_base_url, str_endpoint), tmp_data_file)
+  unzip(tmp_data_file, exdir = paste0("./", year))
+  unlink(tmp_data_file)
+}
 
 # Avoid the R CMD check note about magrittr's dot
 utils::globalVariables(".")

--- a/R/utils.R
+++ b/R/utils.R
@@ -196,8 +196,6 @@ get_data <- function(str_data_name, year, uf, br_archive, ascii, encoding, expor
   str_remote_file_location <- gsub(pattern = '%year%', replacement = year, x = str_remote_file_location)
   str_remote_file_location <- gsub(pattern = '%uf%', replacement = uf, x = str_remote_file_location)
 
-  download_and_unzip_datafile(str_remote_file_location, year)
-
   str_tmp_dir <- tempdir()
   str_file_name <- basename(str_remote_file_location)
   

--- a/R/vote_mun_zone_fed.R
+++ b/R/vote_mun_zone_fed.R
@@ -88,13 +88,8 @@ vote_mun_zone_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FAL
   test_fed_year(year)
   uf <- test_uf(uf)
   test_br(br_archive)
-
-  # Download the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/votacao_candidato_munzona/votacao_candidato_munzona_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+  
+  download_and_unzip_datafile(sprintf("odsele/votacao_candidato_munzona/votacao_candidato_munzona_%s.zip", year), year)
 
   message("Processing the data...")
 

--- a/R/vote_mun_zone_fed.R
+++ b/R/vote_mun_zone_fed.R
@@ -80,28 +80,16 @@
 #' df <- vote_mun_zone_fed(2002)
 #' }
 
-vote_mun_zone_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
-
-
+vote_mun_zone_fed <- function(year, uf = "all", br_archive = FALSE, ascii = FALSE, encoding = "latin1", export = FALSE){
   # Test the input
   test_encoding(encoding)
   test_fed_year(year)
   uf <- test_uf(uf)
   test_br(br_archive)
   
-  download_and_unzip_datafile(sprintf("odsele/votacao_candidato_munzona/votacao_candidato_munzona_%s.zip", year), year)
-
-  message("Processing the data...")
-
-  # Clean the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, br_archive)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-
   # Change variable names
   if(year < 2014){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                       "CODIGO_CARGO", "NUMERO_CAND", "SQ_CANDIDATO", "NOME_CANDIDATO", "NOME_URNA_CANDIDATO",
                       "DESCRICAO_CARGO", "COD_SIT_CAND_SUPERIOR", "DESC_SIT_CAND_SUPERIOR", "CODIGO_SIT_CANDIDATO",
@@ -110,15 +98,15 @@ vote_mun_zone_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FAL
                       "TOTAL_VOTOS")
 
   }else if(year == 2014) { 
-      names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                         "SIGLA_UF", "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                         "CODIGO_CARGO", "NUMERO_CAND", "SQ_CANDIDATO", "NOME_CANDIDATO", "NOME_URNA_CANDIDATO",
                         "DESCRICAO_CARGO", "COD_SIT_CAND_SUPERIOR", "DESC_SIT_CAND_SUPERIOR", "CODIGO_SIT_CANDIDATO",
                         "DESC_SIT_CANDIDATO", "CODIGO_SIT_CAND_TOT", "DESC_SIT_CAND_TOT", "NUMERO_PARTIDO",
                         "SIGLA_PARTIDO", "NOME_PARTIDO", "SEQUENCIAL_LEGENDA", "NOME_COLIGACAO", "COMPOSICAO_LEGENDA",
                         "TOTAL_VOTOS", "TRANSITO")
-  } else{
-      names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO",         
+  } else {
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO",         
                         "NOME_TIPO_ELEICAO", "NUM_TURNO", "COD_ELEICAO", "DESCRICAO_ELEICAO",              
                         "DATA_ELEICAO", "ABRANGENCIA", "SIGLA_UF", "SIGLA_UE", "NOME_UE",                   
                         "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA", "CODIGO_CARGO",                
@@ -129,13 +117,6 @@ vote_mun_zone_fed <- function(year, uf = "all",  br_archive = FALSE, ascii = FAL
                         "SEQUENCIAL_LEGENDA", "NOME_COLIGACAO", "COMPOSICAO_LEGENDA", 
                         "CODIGO_SIT_CAND_TOT", "DESC_SIT_CAND_TOT", "TRANSITO", "TOTAL_VOTOS")
   }
-  
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
 
-  message("Done.\n")
-  return(banco)
+  get_data('votacao_candidato_munzona', year, uf, br_archive, ascii, encoding, export, data_names)
 }

--- a/R/vote_mun_zone_local.R
+++ b/R/vote_mun_zone_local.R
@@ -64,27 +64,16 @@
 #' df <- vote_mun_zone_local(2000)
 #' }
 
-vote_mun_zone_local <- function(year, uf = "all",  ascii = FALSE, encoding = "latin1", export = FALSE){
-
+vote_mun_zone_local <- function(year, uf = "all", ascii = FALSE, encoding = "latin1", export = FALSE){
 
   # Test the input
   test_encoding(encoding)
   test_local_year(year)
   uf <- test_uf(uf)
 
-  download_and_unzip_datafile(sprintf("odsele/votacao_candidato_munzona/votacao_candidato_munzona_%s.zip", year), year)
-
-  message("Processing the data...")
-
-  # Clean the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, FALSE)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-
   # Change variable names
   if(year <= 2012){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO",
                       "SIGLA_UF", "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA",
                       "CODIGO_CARGO", "NUMERO_CAND", "SQ_CANDIDATO", "NOME_CANDIDATO", "NOME_URNA_CANDIDATO",
                       "DESCRICAO_CARGO", "COD_SIT_CAND_SUPERIOR", "DESC_SIT_CAND_SUPERIOR", "CODIGO_SIT_CANDIDATO",
@@ -93,7 +82,7 @@ vote_mun_zone_local <- function(year, uf = "all",  ascii = FALSE, encoding = "la
                       "TOTAL_VOTOS")
   
   } else {
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO",         
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO",         
                       "NOME_TIPO_ELEICAO", "NUM_TURNO", "COD_ELEICAO", "DESCRICAO_ELEICAO",              
                       "DATA_ELEICAO", "ABRANGENCIA", "SIGLA_UF", "SIGLA_UE", "NOME_UE",
                       "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA", "CODIGO_CARGO",
@@ -103,14 +92,7 @@ vote_mun_zone_local <- function(year, uf = "all",  ascii = FALSE, encoding = "la
                       "TIPO_AGREMIACAO", "NUMERO_PARTIDO", "SIGLA_PARTIDO", "NOME_PARTIDO",
                       "SEQUENCIAL_LEGENDA", "NOME_COLIGACAO", "COMPOSICAO_LEGENDA",
                       "CODIGO_SIT_CAND_TOT", "DESC_SIT_CAND_TOT", "TRANSITO","TOTAL_VOTOS" )
-}
+  }
 
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
-
-  message("Done.\n")
-  return(banco)
+  get_data('votacao_candidato_munzona', year, uf, FALSE, ascii, encoding, export, data_names)
 }

--- a/R/vote_mun_zone_local.R
+++ b/R/vote_mun_zone_local.R
@@ -72,12 +72,7 @@ vote_mun_zone_local <- function(year, uf = "all",  ascii = FALSE, encoding = "la
   test_local_year(year)
   uf <- test_uf(uf)
 
-  # Download the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/votacao_candidato_munzona/votacao_candidato_munzona_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+  download_and_unzip_datafile(sprintf("odsele/votacao_candidato_munzona/votacao_candidato_munzona_%s.zip", year), year)
 
   message("Processing the data...")
 

--- a/R/vote_section_fed.R
+++ b/R/vote_section_fed.R
@@ -64,12 +64,7 @@ vote_section_fed <- function(year, uf = "AC", ascii = FALSE, encoding = "latin1"
   if(tolower(uf) == "all") stop("'uf' is invalid. Please, check the documentation and try again.")
   uf <- test_uf(uf)
   
-  # Download the data
-  dados <- tempfile()
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/votacao_secao/votacao_secao_%s_%s.zip", year, uf) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
+  download_and_unzip_datafile(sprintf("odsele/votacao_secao/votacao_secao_%s_%s.zip", year, uf), year)
   
   message("Processing the data...")
   

--- a/R/vote_section_fed.R
+++ b/R/vote_section_fed.R
@@ -56,44 +56,27 @@
 
 vote_section_fed <- function(year, uf = "AC", ascii = FALSE, encoding = "latin1", export = FALSE){
   
-  
+  if(tolower(uf) == "all") {
+    stop("'uf' is invalid. Please, check the documentation and try again.")
+  }
+
   # Test the inputs
   test_encoding(encoding)
   test_fed_year(year)
   stopifnot(is.character(uf))
-  if(tolower(uf) == "all") stop("'uf' is invalid. Please, check the documentation and try again.")
   uf <- test_uf(uf)
-  
-  download_and_unzip_datafile(sprintf("odsele/votacao_secao/votacao_secao_%s_%s.zip", year, uf), year)
-  
-  message("Processing the data...")
-  
-  # Clean the data
-  setwd(as.character(year))
-  banco <- juntaDados(uf, encoding, FALSE)
-  setwd("..")
-  unlink(as.character(year), recursive = T)
-  
-  # Change variable names
+
+  # Variable names
   if(year < 2014){
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO", "SIGLA_UF", "SIGLA_UE",
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO", "SIGLA_UF", "SIGLA_UE",
                       "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA", "NUMERO_SECAO", "CODIGO_CARGO", "DESCRICAO_CARGO",
                       "NUM_VOTAVEL", "QTDE_VOTOS")
   } else{
-    names(banco) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO", "NUM_TURNO",       
+    data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "COD_TIPO_ELEICAO", "NOME_TIPO_ELEICAO", "NUM_TURNO",       
                       "COD_ELEICAO", "DESCRICAO_ELEICAO", "DATA_ELEICAO", "ABRANGENCIA", "SIGLA_UF", "SIGLA_UE", "NOME_UE",  
                       "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA", "NUMERO_SECAO", "CODIGO_CARGO", "DESCRICAO_CARGO",
                       "NUM_VOTAVEL", "NOME_VOTAVEL", "QTDE_VOTOS")
   }
 
-    
-
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
-  
-  message("Done.\n")
-  return(banco)
+  get_data('votacao_secao', year, uf, FALSE, ascii, encoding, export, data_names)
 }

--- a/R/vote_section_local.R
+++ b/R/vote_section_local.R
@@ -55,74 +55,35 @@
 #' }
 
 vote_section_local <- function(year, uf = "AC", ascii = FALSE, encoding = "latin1", export = FALSE){
-  
-  
+
+  if(tolower(uf) == "all") {
+    stop("'uf' is invalid. Please, check the documentation and try again.") 
+  }
+
   # Test the inputs
   test_encoding(encoding)
   test_local_year(year)
   stopifnot(is.character(uf))
-  if(tolower(uf) == "all") stop("'uf' is invalid. Please, check the documentation and try again.")
   uf <- test_uf(uf)
+
+  # Variable names
+  data_names <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO", "SIGLA_UF",
+                  "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA", "NUMERO_SECAO", "CODIGO_CARGO", 
+                  "DESCRICAO_CARGO","NUM_VOTAVEL", "QTDE_VOTOS")
   
-  if(year < 2012){
-    
-    download_and_unzip_datafile(sprintf("odsele/votacao_secao/votacao_secao_%s_%s.zip", year, uf), year)
-
-    message("Processing the data...")
-    
-    # Clean the data
-    setwd(as.character(year))
-    banco <- juntaDados(uf, encoding, FALSE)
-    setwd("..")
-    unlink(as.character(year), recursive = T)
-    
-  } else{
-    message("Download the data One...")
-    
-    download_and_unzip_datafile(sprintf("/eleicoes/eleicoes2012/votosecao/vsec_1t_%s.zip", uf), year)
-
-    message("Processing the data one...")
-    
-    # Clean the data
-    setwd(as.character(year))
-    banco1 <- juntaDados(uf, encoding, FALSE)
-    setwd("..")
-    unlink(as.character(year), recursive = T)
-    
+  
+  if (year < 2012) {
+    banco <- get_data('votacao_secao', year, uf, FALSE, ascii, encoding, export, data_names)
+  } else {
+    banco <- get_data('vsec_1t', year, uf, FALSE, ascii, encoding, export, data_names)
     
     if(!(uf %in% c("AL", "DF", "GO", "PE", "RR", "SE", "TO"))){
 
-      message("Download the data two...")
-
-      download_and_unzip_datafile(sprintf("eleicoes/eleicoes2012/votosecao/vsec_2t_%s_30102012194527.zip", uf), year)
-
-      message("Processing the data two...")
+      banco2 <- get_data('vsec_2t_', year, uf, FALSE, ascii, encoding, export, data_names)
       
-      # Clean the data
-      setwd(paste0("./", year, "2"))
-      banco2 <- juntaDados(uf, encoding, FALSE)
-      setwd("..")
-      unlink(paste0("./", year, "2"), recursive = T)
-      
-    }else{
-      banco2 <- NULL
+      banco <- rbind(banco, banco2)
     }
-    
-    banco <- rbind(banco1, banco2)
   }
-  
-  # Change variable names
-  names(vts_local) <- c("DATA_GERACAO", "HORA_GERACAO", "ANO_ELEICAO", "NUM_TURNO", "DESCRICAO_ELEICAO", "SIGLA_UF",
-                        "SIGLA_UE", "CODIGO_MUNICIPIO", "NOME_MUNICIPIO", "NUMERO_ZONA", "NUMERO_SECAO", "CODIGO_CARGO", 
-                        "DESCRICAO_CARGO","NUM_VOTAVEL", "QTDE_VOTOS")
 
-  
-  # Change to ascii
-  if(ascii == T) banco <- to_ascii(banco, encoding)
-  
-  # Export
-  if(export) export_data(banco)
-  
-  message("Done.\n")
   return(banco)
 }

--- a/R/vote_section_local.R
+++ b/R/vote_section_local.R
@@ -66,13 +66,8 @@ vote_section_local <- function(year, uf = "AC", ascii = FALSE, encoding = "latin
   
   if(year < 2012){
     
-    # Download the data
-    dados <- tempfile()
-    sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/votacao_secao/votacao_secao_%s_%s.zip", year, uf) %>%
-      download.file(dados)
-    unzip(dados, exdir = paste0("./", year))
-    unlink(dados)
-    
+    download_and_unzip_datafile(sprintf("odsele/votacao_secao/votacao_secao_%s_%s.zip", year, uf), year)
+
     message("Processing the data...")
     
     # Clean the data
@@ -84,12 +79,8 @@ vote_section_local <- function(year, uf = "AC", ascii = FALSE, encoding = "latin
   } else{
     message("Download the data One...")
     
-    dados <- tempfile()
-    sprintf("http://agencia.tse.jus.br/estatistica/sead/eleicoes/eleicoes2012/votosecao/vsec_1t_%s.zip", uf) %>%
-      download.file(dados)
-    unzip(dados, exdir = paste0("./", year))
-    unlink(dados)
-    
+    download_and_unzip_datafile(sprintf("/eleicoes/eleicoes2012/votosecao/vsec_1t_%s.zip", uf), year)
+
     message("Processing the data one...")
     
     # Clean the data
@@ -100,15 +91,11 @@ vote_section_local <- function(year, uf = "AC", ascii = FALSE, encoding = "latin
     
     
     if(!(uf %in% c("AL", "DF", "GO", "PE", "RR", "SE", "TO"))){
-      
+
       message("Download the data two...")
-      
-      dados2 <- tempfile()
-      sprintf("http://agencia.tse.jus.br/estatistica/sead/eleicoes/eleicoes2012/votosecao/vsec_2t_%s_30102012194527.zip", uf) %>%
-        download.file(dados2)
-      unzip(dados2, exdir = paste0("./", year, "2"))
-      unlink(dados2)
-      
+
+      download_and_unzip_datafile(sprintf("eleicoes/eleicoes2012/votosecao/vsec_2t_%s_30102012194527.zip", uf), year)
+
       message("Processing the data two...")
       
       # Clean the data

--- a/R/voter_profile.R
+++ b/R/voter_profile.R
@@ -45,14 +45,8 @@ voter_profile <- function(year, ascii = FALSE, encoding = "windows-1252", export
   if(!year %in% seq(1994, 2018, by = 2)) stop("Invalid 'year'. Please check the documentation and try again.")
   test_encoding(encoding)
   
-  # Download data
-  dados <- tempfile()
+  download_and_unzip_datafile(sprintf("odsele/perfil_eleitorado/perfil_eleitorado_%s.zip", year), year)
 
-  sprintf("http://agencia.tse.jus.br/estatistica/sead/odsele/perfil_eleitorado/perfil_eleitorado_%s.zip", year) %>%
-    download.file(dados)
-  unzip(dados, exdir = paste0("./", year))
-  unlink(dados)
-  
   # Join data
   message("Processing the data...")
     


### PR DESCRIPTION
Proposta para agilizar a manipulação dos dados e melhorar eficiência do uso das redes.

Na versão atual, o script sempre faz download dos arquivos do site do TSE. No caso da pessoa criar dois dataframes com o mesmo arquivo de origem, o arquivo é descarregado duas vezes. Por exemplo:

```r
> df_elec_fed_ac <- electionsBR::candidate_fed(2014, "AC")
trying URL 'http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_cand/consulta_cand_2014.zip'
Content type 'application/zip' length 5585613 bytes (5.3 MB)
==================================================
downloaded 5.3 MB

Processing the data...
Done.

> df_elec_fed_am <- electionsBR::candidate_fed(2014, "AM")
trying URL 'http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_cand/consulta_cand_2014.zip'
Content type 'application/zip' length 5585613 bytes (5.3 MB)
==================================================
downloaded 5.3 MB

Processing the data...
Done.
```

A proposta dessas alterações é permitir às pessoas configurar uma pasta local para armazenar os arquivos e passar a ler os dados dessa pasta local. Se trabalhar com dados locais pode levar o usuário a utilizar dados desatualizados, o risco é compensado ao promover agilidade de quem não tem uma excelente conexão de internet. Importante destacar que sem definir essa configuração o script permanecerá com o comportamento atual de sempre baixar os arquivos.
Para implementar essa configuração foi levado em consideração que o TSE não realiza alterações nos arquivos com alta frequência, não será em horas ou mesmo semanas, que haverá defasagem de dados. Também foi considerado o princípio de desenvolvimento em Python de que somos todos [adultos responsáveis](https://python-guide-chinese.readthedocs.io/zh_CN/latest/writing/style.html).

Por meio da função options do pacote base do R, o usuário pode configurar a pasta de downloads dos arquivos na variável electionsBR-data-path. Por exemplo:

```r
> options('electionsBR-data-path' = '~/Documents/dados_tse')
```

Ao executar as funções o script primeiro buscará os arquivos na pasta configurada no passo anterior e, se não encontrar, então, fará o descarregamento do arquivo.

```r
> df_elec_fed_ac <- electionsBR::candidate_fed(2014, "AC")
Downloading data to: ~/Documents/dados_tse/consulta_cand_2014.zip
trying URL 'http://agencia.tse.jus.br/estatistica/sead/odsele/consulta_cand/consulta_cand_2014.zip'
Content type 'application/zip' length 5585613 bytes (5.3 MB)
==================================================
downloaded 5.3 MB

Processing the data...
Done.

> df_elec_fed_am <- electionsBR::candidate_fed(2014, "AM")
Processing the data...
Done.
```

Com essa alteração, na segunda execução da função candidate_fed o script utiliza o arquivo já descarregado pela execução anterior.

O script foi [refatorado](https://pt.wikipedia.org/wiki/Refatora%C3%A7%C3%A3o) para centralizar o tratamento dos arquivos em três funções. Nessa refatoração foi considerado o [princípio Don't repeat Yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) de não redundância de código. Isso facilitou a implementação da função de verificação da opção de pasta local e dos arquivos descarregados. E, também, preparou a estrutura do código para agilizar futuras manutenções na função de tratamento arquivos, como por exemplo, verificar a versão dos arquivos remotos e sugerir ao usuário o novo download.
