### PR TITLE
Mudanças na função parties_br( ) 

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -82,6 +82,13 @@ to_ascii <- function(banco, encoding){
 }
 
 
+# Tests election year inputs
+test_year <- function(year){
+
+  if (!is.numeric(year) | length(year) != 1 | !year %in% seq(1994, 2020, 2)) stop("Invalid input. Please, check the documentation and try again.")
+}
+
+
 # Tests federal election year inputs
 test_fed_year <- function(year){
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,14 +24,95 @@ uf_br <- function() {
 #' 
 #' @export
 
-parties_br <- function() {
-  
-  c("AVANTE", "CIDADANIA", "DC", "DEM", "MDB", "NOVO", "PATRIOTA", 
-    "PC do B", "PCB", "PCO", "PDT", "PEN", "PHS", "PMB", "PMN", "PODE", 
-    "PP", "PPL", "PPS", "PR", "PRB", "PROS", "PRP", "PRTB", "PSB", 
-    "PSC", "PSD", "PSDB", "PSDC", "PSL", "PSOL", "PSTU", "PT", "PT do B", 
-    "PTB", "PTC", "PTN", "PV", "REDE", "REPUBLICANOS", "SD", "SOLIEDARIEDADE", 
-    "UP")
+parties_br <- function(year) {
+
+  # Input test
+  test_year(year)
+
+  if (year == 1994) {
+    result <- c("PPR", "PT", "PMDB", "PRONA", "PL", "PDT", "PTB", "PSTU", "PFL",
+                "PP", "PSB", "PV", "PSDB", "PC DO B", "PPS", "PMN", "PSC", "PRN",
+                "PSD", "PRP", "PT DO B", "PTRB")
+
+  } else if (year == 1996) {
+    result <- c("PPB", "PT", "PMDB", "PSDB", "PFL", "PC DO B", "PSL", "PDT", "PMN",
+                "PT DO B", "PTB", "PL", "PSB", "PV", "PSD", "PRP", "PRN", "PSTU",
+                "PST", "PSC", "PPS", "PRTB", "PRONA", "PSDC", "PAN", "PCO", "PGT",
+                "PCB", "PSN", "PTN")
+
+  } else if (year == 1998) {
+    result <- c("PT", "PMDB", "PFL", "PRONA", "PPB", "PSDB", "PDT", "PSTU", "PL",
+                "PMN", "PSB", "PC do B", "PT do B", "PTB", "PPS", "PV", "PSL",
+                "PRN", "PSD", "PAN", "PTN", "PRTB", "PSN", "PSC", "PRP", "PST",
+                "PSDC", "PCB", "PGT", "PCO")
+
+  } else if (year == 2000) {
+    result <- c("PFL", "PSDB", "PPB", "PT", "PPS", "PRTB", "PMN", "PSB", "PV",
+                "PC do B", "PMDB", "PTB", "PDT", "PT do B", "PSTU", "PL", "PRONA",
+                "PSL", "PST", "PTN", "PSDC", "PRP", "PGT", "PSD", "PSC", "PRN",
+                "PHS", "PAN", "PCB", "PCO")
+
+  } else if (year == 2002) {
+    result <- c("PT", "PMDB", "PSL", "PPS", "PRTB", "PTB", "PSB", "PSDB", "PPB",
+                "PDT", "PST", "PSC", "PL", "PFL", "PMN", "PV", "PC do B", "PSDC",
+                "PT do B", "PSTU", "PTN", "PAN", "PGT", "PHS", "PTC", "PRP",
+                "PRONA", "PSD", "PCB", "PCO")
+
+  } else if (year == 2004) {
+    result <- c("PTB", "PT", "PSDB", "PMDB", "PSB", "PFL", "PDT", "PPS", "PMN",
+                "PV", "PC do B", "PP", "PL", "PSDC", "PT do B", "PSL", "PSC", "PTN",
+                "PRTB", "PRP", "PRONA", "PAN", "PTC", "PHS", "PSTU", "PCB", "PCO")
+
+  } else if (year == 2006) {
+    result <- c("PT", "PAN", "PSDC", "PRONA", "PSOL", "PPS", "PSDB", "PP", "PDT",
+                "PFL", "PMDB", "PTB", "PRP", "PL", "PV", "PSB", "PC do B", "PRTB",
+                "PMN", "PTN", "PTC", "PHS", "PT do B", "PCB", "PSC", "PSTU", "PRB",
+                "PCO", "PSL")
+
+  } else if (year == 2008) {
+    result <- c("PT", "PSDB", "PP", "PMDB", "PRP", "PR", "PSB", "PMN", "PV", "PC do B",
+                "PRB", "PTN", "PSOL", "PTC", "PPS", "DEM", "PSDC", "PT do B", "PHS",
+                "PSC", "PTB", "PDT", "PSL", "PRTB", "PCB", "PSTU", "PCO")
+
+  } else if (year == 2010) {
+    result <- c("PRTB", "PSDB", "PT", "PP", "PPS", "PSOL", "PC do B", "PMDB", "PMN",
+                "PSC", "PR", "PTN", "PRP", "PSDC", "PTC", "PV", "PDT", "PSB", "DEM",
+                "PTB", "PRB", "PHS", "PT do B", "PSL", "PCB", "PSTU", "PCO")
+
+  } else if (year == 2012) {
+    result <- c("DEM", "PMN", "PDT", "PP", "PMDB", "PSDC", "PC do B", "PT", "PSDB",
+                "PTB", "PRP", "PPS", "PSD", "PSB", "PR", "PSL", "PRB", "PV", "PTN",
+                "PSC", "PT do B", "PPL", "PRTB", "PHS", "PTC", "PSOL", "PSTU",
+                "PCB", "SD", "PCO")
+
+  } else if (year == 2014) {
+    result <- c("PSB", "PSDB", "PT do B", "PC do B", "PSD", "PHS", "DEM", "PDT", "PP",
+                "PT", "PRP", "PTN", "PRB", "PSDC", "PSOL", "PEN", "PV", "PPS", "SD",
+                "PR", "PPL", "PMN", "PSC", "PTC", "PMDB", "PSL", "PTB", "PROS",
+                "PRTB", "PCB", "PSTU", "PODE", "REDE", "PCO")
+
+  } else if (year == 2016) {
+    result <- c("PTC", "PR", "REDE", "PSDC", "PTN", "PC do B", "PRB", "PSD", "DEM",
+                "PHS", "PT", "PSB", "PROS", "PMDB", "PSL", "PSDB", "PDT", "PP", "PRP",
+                "PMB", "PV", "PSC", "PTB", "PSOL", "PMN", "SD", "PPS", "PT do B",
+                "PATRIOTA", "PRTB", "PPL", "PSTU", "PODE", "MDB", "PCB", "PCO", "PL",
+                "SOLIDARIEDADE", "DC", "NOVO", "CIDADANIA", "AVANTE", "REPUBLICANOS")
+
+  } else if (year == 2018) {
+    result <- c("PTC", "DEM", "PT", "PR", "PSL", "PSDB", "PSB", "MDB", "PSOL", "PDT",
+                "PTB", "REDE", "PRTB", "SOLIDARIEDADE", "PPS", "PMB", "PRB", "PROS", "PPL",
+                "PP", "PRP", "PHS", "PMN", "PSD", "PSC", "PV", "PODE", "DC", "PATRIOTA",
+                "AVANTE", "PC do B", "PCO", "PSTU", "NOVO", "PCB", "PL", "CIDADANIA")
+
+  } else if (year == 2020) {
+    result <- c("MDB", "PL", "PSD", "PT", "PSDB", "PROS", "PP", "PDT", "PSB", "SOLIDARIEDADE",
+                "PSL", "CIDADANIA", "PSC", "PTB", "PC do B", "REPUBLICANOS", "DEM",
+                "PSOL", "PATRIOTA", "PCO", "AVANTE", "PODE", "DC", "PMB", "PV",
+                "PMN", "PCB", "PRTB", "REDE", "PTC", "UP", "PSTU", "NOVO")
+
+  }
+
+  return(result)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,9 +20,17 @@ uf_br <- function() {
 
 #' Returns a vector with the abbreviations of all Brazilian parties
 #'
-#' The character vector includes only parties that ran in elections in 2016.
-#' 
+#' The character vector includes only parties that ran in elections from 1994 to 2020.
+#'
+#' @param year Election year. For this function, only the years of 1994, 1996, 1998,
+#' 2000, 2002, 2004, 2006, 2008, 2010, 2012, 2014, 2016, 2018, and 2020 are available.
+#'
 #' @export
+#'
+#' @examples
+#' \dontrun{
+#' parties_election2002 <- parties_br(year = 2002)
+#' }
 
 parties_br <- function(year) {
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,20 +97,19 @@ parties_br <- function(year) {
     result <- c("PSB", "PSDB", "PT do B", "PC do B", "PSD", "PHS", "DEM", "PDT", "PP",
                 "PT", "PRP", "PTN", "PRB", "PSDC", "PSOL", "PEN", "PV", "PPS", "SD",
                 "PR", "PPL", "PMN", "PSC", "PTC", "PMDB", "PSL", "PTB", "PROS",
-                "PRTB", "PCB", "PSTU", "PODE", "REDE", "PCO")
+                "PRTB", "PCB", "PSTU", "REDE", "PCO")
 
   } else if (year == 2016) {
     result <- c("PTC", "PR", "REDE", "PSDC", "PTN", "PC do B", "PRB", "PSD", "DEM",
                 "PHS", "PT", "PSB", "PROS", "PMDB", "PSL", "PSDB", "PDT", "PP", "PRP",
                 "PMB", "PV", "PSC", "PTB", "PSOL", "PMN", "SD", "PPS", "PT do B",
-                "PATRIOTA", "PRTB", "PPL", "PSTU", "PODE", "MDB", "PCB", "PCO", "PL",
-                "SOLIDARIEDADE", "DC", "NOVO", "CIDADANIA", "AVANTE", "REPUBLICANOS")
+                "PRTB", "PPL", "PSTU", "PCB", "PCO", "SOLIDARIEDADE", "NOVO")
 
   } else if (year == 2018) {
     result <- c("PTC", "DEM", "PT", "PR", "PSL", "PSDB", "PSB", "MDB", "PSOL", "PDT",
                 "PTB", "REDE", "PRTB", "SOLIDARIEDADE", "PPS", "PMB", "PRB", "PROS", "PPL",
                 "PP", "PRP", "PHS", "PMN", "PSD", "PSC", "PV", "PODE", "DC", "PATRIOTA",
-                "AVANTE", "PC do B", "PCO", "PSTU", "NOVO", "PCB", "PL", "CIDADANIA")
+                "AVANTE", "PC do B", "PCO", "PSTU", "NOVO", "PCB", "PL")
 
   } else if (year == 2020) {
     result <- c("MDB", "PL", "PSD", "PT", "PSDB", "PROS", "PP", "PDT", "PSB", "SOLIDARIEDADE",


### PR DESCRIPTION
O objetivo desta contribuição é modificar o uso da função `electionsBR::parties_br()`. Atualmente, a função retorna um vetor, contendo a sigla de partidos políticos brasileiros (43). A documentação do pacote diz que esse vetor apresenta partidos "that ran in elections in 2016", mas a função retorna partidos como a "UP", que foi reconhecida pelo TSE apenas em 2019. Ao mesmo tempo, a função retorna algumas inconsistências, por exemplo, PPS e CIDADANIA que são, na verdade, o mesmo partido, que teve uma mudança de nome em 2019. O mesmo acontece com PRB e REPUBLICANOS:

```r

> electionsBR::parties_br()
[1] "AVANTE"         "CIDADANIA"      "DC"            
 [4] "DEM"            "MDB"            "NOVO"          
 [7] "PATRIOTA"       "PC do B"        "PCB"           
[10] "PCO"            "PDT"            "PEN"           
[13] "PHS"            "PMB"            "PMN"           
[16] "PODE"           "PP"             "PPL"           
[19] "PPS"            "PR"             "PRB"           
[22] "PROS"           "PRP"            "PRTB"          
[25] "PSB"            "PSC"            "PSD"           
[28] "PSDB"           "PSDC"           "PSL"           
[31] "PSOL"           "PSTU"           "PT"            
[34] "PT do B"        "PTB"            "PTC"           
[37] "PTN"            "PV"             "REDE"          
[40] "REPUBLICANOS"   "SD"             "SOLIEDARIEDADE"
[43] "UP"

```
 
A proposta é corrigir tais inconsistências e permitir o usuário escolher consultar os partidos políticos que concorreram nas eleições de determinado ano. Com a mudança na função, buscando obter os partidos que concorreram nas eleições em 2020, utilizaríamos: 

```r

> electionsBR::parties_br(year = 2020)
[1] "MDB"           "PL"            "PSD"          
 [4] "PT"            "PSDB"          "PROS"         
 [7] "PP"            "PDT"           "PSB"          
[10] "SOLIDARIEDADE" "PSL"           "CIDADANIA"    
[13] "PSC"           "PTB"           "PC do B"      
[16] "REPUBLICANOS"  "DEM"           "PSOL"         
[19] "PATRIOTA"      "PCO"           "AVANTE"       
[22] "PODE"          "DC"            "PMB"          
[25] "PV"            "PMN"           "PCB"          
[28] "PRTB"          "REDE"          "PTC"          
[31] "UP"            "PSTU"          "NOVO"

```

Segue o código utilizado para indentificar os partidos presentes em cada eleição:

```r

library(tidyverse)
library(electionsBR)

options(timeout = 60 * 20)

get_data <- function() {
  fed_years <- c(1994, 1998, 2002, 2006, 2010, 2014, 2018)
  local_years <- c(1996, 2000, 2004, 2008, 2012, 2016, 2020)

  fed <- purrr::map(fed_years, ~ electionsBR::candidate_fed(year = .x))
  local <- purrr::map(local_years, ~ electionsBR::candidate_local(year = .x))

  return(c(fed, local))
}

# Lista com a base de candidatos de todas as eleições
data <- get_data()

# ...

myl <- list()

# Lista com os partidos presentes em cade eleição
for (i in 1:14) {
  myl[[i]] <- data.frame(
    ano = unique(data[[i]]$ANO_ELEICAO),
    partidos = unique(select(data[[i]], matches("SIGLA_PARTIDO|SG_PARTIDO"))) %>% pull()
  )
}

# Transforma em dataframe e concatena os partidos por ano
df <- do.call("rbind", myl) %>%
  group_by(ano) %>%
  summarise(partidos = strsplit(paste(partidos, collapse = ","), ","))

``` 

Mesmo com o código acima, ainda foi necessário excluir **manualmente** alguns partidos, devido a problemas no próprio cadastro dos candidatos. Por exemplo, na base de candidatos de 2016, encontram-se candidatos de ambos CIDADANIA, que ainda se chamava PPS, e PPS. 

O resultado final é a criação da função `test_year()`, a modificação da função `parties_br()` e uma pequena atualização na documentação de acordo com as mudanças feitas no código.

PS: É a primeira vez que contribuo com algum projeto open source, meu primeiro pull request, então peço desculpas de antemão por qualquer coisa. Gosto muito do pacote, uso em minhas pesquisas e em trabalhos, então fico feliz em contribuir para aprimorar o pacote. 