### PR TITLE
Add httr GET

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,12 +15,14 @@ Description: Offers a set of functions to easily download and clean
     state, city, and electoral zones. 
 License: GPL (>= 2)
 Depends: R (>= 3.1.2)
-Imports: magrittr,
+Imports: 
+    magrittr,
     dplyr (>= 1.0.0),
     data.table (>= 1.9.8),
     haven (>= 1.0.0),
     readr,
-    stats
+    stats,
+    httr
 LazyData: TRUE
 URL: http://electionsbr.com/
 BugReports: https://github.com/silvadenisson/electionsBR/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# electionsBR 0.3.3
+
+* Implement httr's GET to download files to avoid TSE's server instability
+* Fix the function vote_section_local and vote_mun_zone_fed
+
 # electionsBR 0.3.2
 
 This is a minor update fixing the functions to download and clean electoral data by voting sections in municipal elections. We also added support to continuous integrations tests with GitHub Actions. 

--- a/R/utils.R
+++ b/R/utils.R
@@ -173,7 +173,8 @@ download_unzip <- function(url, dados, filenames, year){
   if(!file.exists(dados)){
     
     sprintf(url, filenames) %>%
-      download.file(dados)
+      httr::GET(httr::write_disk(path = dados, overwrite = TRUE),
+                httr::progress())
     
     message("Processing the data...")
     unzip(dados, exdir = paste0("./", year))


### PR DESCRIPTION
Este PR implementa downloads de arquivos por meio da função GET do pacote httr. Justificativa: por conta de instabilidade nos servidores do TSE, estava tendo muitos downloads interrompidos sem razão aparente; como o httr gerencia melhor requisições, consegui contornar o problema com ele. Me parece uma melhor solução para o longo prazo.