### PR TITLE
Insere documentação do argumento 'uf' na função voter_profile_by_section.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     stats,
     httr
 LazyData: TRUE
+Encoding: UTF-8
 URL: http://electionsbr.com/
 BugReports: https://github.com/silvadenisson/electionsBR/issues
 RoxygenNote: 7.2.0

--- a/R/voter_profile_by_section.R
+++ b/R/voter_profile_by_section.R
@@ -6,6 +6,8 @@
 #' @param year Election year (\code{integer}). For this function, the following years are available: 1994, 1996, 1998,
 #' 2000, 2002, 2004, 2006, 2008, 2010, 2012, 2014, 2016, 2018 and 2020.
 #' 
+#' @param uf Federation Unit acronym (\code{character vector}). Defaults to \code{'AC'} (Acre).
+#' 
 #' @param ascii (\code{logical}). Should the text be transformed from Latin-1 to ASCII format?
 #'
 #' @param encoding Data original encoding (defaults to 'windows-1252'). This can be changed to avoid errors

--- a/man/voter_profile_by_section.Rd
+++ b/man/voter_profile_by_section.Rd
@@ -17,6 +17,8 @@ voter_profile_by_section(
 \item{year}{Election year (\code{integer}). For this function, the following years are available: 1994, 1996, 1998,
 2000, 2002, 2004, 2006, 2008, 2010, 2012, 2014, 2016, 2018 and 2020.}
 
+\item{uf}{Federation Unit acronym (\code{character vector}). Defaults to \code{'AC'} (Acre).}
+
 \item{ascii}{(\code{logical}). Should the text be transformed from Latin-1 to ASCII format?}
 
 \item{encoding}{Data original encoding (defaults to 'windows-1252'). This can be changed to avoid errors


### PR DESCRIPTION
O argumento 'uf' da função não estava documentado. O inseri seguindo o mesmo texto usado em outras funções. Contudo, para atualizar a documentação com 'devtools::document()' foi necessário inserir  'Encoding: UTF-8' no arquivo DESCRIPTION. No momento, não sei se a mudança pode provocar efeitos colaterais. 